### PR TITLE
fix: add customer api should not provide 'id' 

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -76,7 +76,6 @@ class Customer(db.Model):
             data (dict): A dictionary containing the resource data
         """
         try:
-            self.id=data["id"]
             self.username = data["username"]
             self.password=data["password"]
             self.first_name=data["first_name"]

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -86,8 +86,8 @@ class TestYourResourceServer(TestCase):
             self.assertEqual(
                 resp.status_code, status.HTTP_201_CREATED, "Could not create test product"
             )
-            new_product = resp.get_json()
-            test_customer.id = new_product["id"]
+            new_customer = resp.get_json()
+            test_customer.id = new_customer["id"]
             customers.append(test_customer)
         return customers
 


### PR DESCRIPTION
fixed new_product to new_customers in _create_customers()