### PR TITLE
Issue 8 - update addresses subordinate endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To install the requirements for the service, from the command line run:
 
 To start the service, from the command line run:
 ```bash
-    FLASK_APP=service:app flask run
+    FLASK_APP=service:app flask run -h 0.0.0.0
 ```
 
 The app runs on `localhost:5000`
@@ -34,11 +34,11 @@ To run the tests for the service, from the command line run:
     * Sample JSON request body format:
     ```
     {
-        first_name: "John",  
-        last_name: "Smith",  
-        user_name: "XXX",  
-        addresses: ["123 Main St, Buffalo, NY", "50 John Street, NY"],  
-        password: "XXX"  
+        "first_name": "John",  
+        "last_name": "Smith",  
+        "username": "XXX",  
+        "addresses": ["123 Main St, Buffalo, NY", "50 John Street, NY"],  
+        "password": "XXX"  
     }
     ```
 - Read a customer's information:
@@ -49,7 +49,8 @@ To run the tests for the service, from the command line run:
 - Update a customer's information:
     * `PUT /customers/{customer_id}`
     * The parameter customer_id is expected to be an integer equal to the unique id of a customer
-    * The JSON request body is expected to contain one or more of the following keys: ``first_name, last_name, user_name, addresses, password``
+    * The JSON request body is expected to contain all of the following keys: ``first_name, last_name, user_name, addresses, password``
+    * If the JSON request body is missing one or more of the required keys, an error will be thrown
     * The expected types of the values for each of the possible keys are as follows:
         - first_name: string
         - last_name: string
@@ -59,8 +60,8 @@ To run the tests for the service, from the command line run:
     * Sample JSON request body format:
     ```
     { 
-        first_name: "Johnny", 
-        password: "YYY"
+        "first_name": "Johnny", 
+        "password": "YYY"
     }
     ```
 - Update a customer's addresses:
@@ -70,7 +71,7 @@ To run the tests for the service, from the command line run:
     * Sample JSON request body format:
     ```
     { 
-        addresses: ["123 Main St, Buffalo, NY", "50 John Street, NY"]  
+        "addresses": ["123 Main St, Buffalo, NY", "50 John Street, NY"]  
     }
     ```
     * If successful, the stored addresses of the customer will be equivalent to the value of the ``addresses`` key in the JSON request body

--- a/service/models.py
+++ b/service/models.py
@@ -92,10 +92,15 @@ class Customer(db.Model):
         """
         try:
             self.username = data["username"]
-            self.password=data["password"]
-            self.first_name=data["first_name"]
-            self.last_name=data["last_name"]
-            self.addresses=data["addresses"]
+            self.password = data["password"]
+            self.first_name = data["first_name"]
+            self.last_name = data["last_name"]
+            self.addresses = data["addresses"]
+
+            if not isinstance(self.addresses, list) or not all(isinstance(s, str) for s in self.addresses):
+                raise DataValidationError(
+                    "Invalid Customer: body of request must be an array of strings"
+            )
 
         except KeyError as error:
             raise DataValidationError(

--- a/service/routes.py
+++ b/service/routes.py
@@ -56,6 +56,38 @@ def update_customers(customer_id):
     return make_response(jsonify(customer.serialize()), status.HTTP_200_OK)
 
 ######################################################################
+# UPDATE AN EXISTING CUSTOMER'S ADDRESSES
+######################################################################
+@app.route("/customers/<int:customer_id>/addresses", methods=["PUT"])
+def update_customer_addresses(customer_id):
+    """
+    Update a Customer's addresses
+    This endpoint will update a Customer's addresses based on the request body.
+    """
+    app.logger.info("Request to update addresses of Customer with id: %s", customer_id)
+    check_content_type("application/json")
+    customer = Customer.find(customer_id)
+    if not customer:
+        raise NotFound("customer with id '{}' was not found.".format(customer_id))
+
+    customer_dict = customer.serialize()
+    request_body = request.get_json()
+
+    if not "addresses" in request_body.keys():
+        raise DataValidationError(
+            "Invalid request body: missing Customer addresses"
+        )
+
+    customer_dict["addresses"] = request_body["addresses"]
+    customer.deserialize(customer_dict)
+
+    customer.id = customer_id
+    customer.update()
+
+    app.logger.info("addresses for customer with ID [%s] updated.", customer.id)
+    return make_response(jsonify(customer.serialize()), status.HTTP_200_OK)
+
+######################################################################
 # GET Information About the Service
 ######################################################################
 @app.route("/customers", methods=["GET"])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -123,6 +123,19 @@ class TestYourResourceModel(unittest.TestCase):
         customer = CustomerFactory()
         self.assertRaises(DataValidationError, customer.deserialize, data)
 
+    def test_deserialize_bad_addresses(self):
+        """Test deserialize a customer with an invalid type for addresses"""
+        data = {
+            "id": 1,
+            "username": "deserialize",
+            "password": "123",
+            "first_name": "Yongchang",
+            "last_name": "Liu",
+            "addresses": [[]]
+        }
+        customer = CustomerFactory()
+        self.assertRaises(DataValidationError, customer.deserialize, data)   
+
     def test_deserialize_bad_data(self):
         """Test deserialize bad data"""
         data = "this is not a dictionary"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -178,7 +178,7 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(data["name"], "API_list")
         
     def test_update_customer(self):
-        """Update an existing customer"""
+        """ Update an existing customer """
         # create a customer to update
         test_customer = CustomerFactory()
         resp = self.app.post(
@@ -198,3 +198,61 @@ class TestYourResourceServer(TestCase):
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
         updated_customer = resp.get_json()
         self.assertEqual(updated_customer["username"], "new_username")
+
+    def test_update_customer_not_found(self):
+        """ Update the addresses of a customer that is not found """
+        resp = self.app.put(
+            "/customers/{}".format(0),
+            content_type = CONTENT_TYPE_JSON
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_addresses(self):
+        """ Update an existing customer's addresses """
+        # create a customer to update
+        test_customer = CustomerFactory()
+        resp = self.app.post(
+            BASE_URL, json=test_customer.serialize(), content_type=CONTENT_TYPE_JSON
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # update the customer's addresses
+        new_address_customer = resp.get_json()
+        logging.debug(new_address_customer)
+        new_addresses = ["123 testing lane", "932 my new address"]
+        new_address_customer["addresses"] = new_addresses
+        resp = self.app.put(
+            "/customers/{}/addresses".format(new_address_customer["id"]),
+            json = new_address_customer,
+            content_type = CONTENT_TYPE_JSON,
+        )
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        updated_customer = resp.get_json()
+        self.assertEqual(updated_customer["addresses"], new_addresses)
+
+    def test_update_addresses_missing(self):
+        """ Update a customer's addresses with addresses missing in request """
+        # create a customer to update
+        test_customer = CustomerFactory()
+        resp = self.app.post(
+            BASE_URL, json=test_customer.serialize(), content_type=CONTENT_TYPE_JSON
+        )
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+
+        # update the customer's addresses
+        new_address_customer = resp.get_json()
+        logging.debug(new_address_customer)
+        resp = self.app.put(
+            "/customers/{}/addresses".format(new_address_customer["id"]),
+            json = dict(),
+            content_type = CONTENT_TYPE_JSON,
+        )
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_update_addresses_not_found(self):
+        """ Update the addresses of a customer that is not found """
+        resp = self.app.put(
+            "/customers/{}/addresses".format(0),
+            content_type = CONTENT_TYPE_JSON
+        )
+        self.assertEqual(resp.status_code, status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
Added endpoint for updating addresses, updated README for customer updates, fixed issue that causes a 500 to be thrown when the value for addresses in the request body is not an array of strings